### PR TITLE
Update gbnf_grammar_from_pydantic_models.py

### DIFF
--- a/src/llama_cpp_agent/gbnf_grammar_generator/gbnf_grammar_from_pydantic_models.py
+++ b/src/llama_cpp_agent/gbnf_grammar_generator/gbnf_grammar_from_pydantic_models.py
@@ -1598,8 +1598,8 @@ def create_dynamic_model_from_function(
         ].description = "Deep inner monologue private to you only."
     for name, param_doc in param_docs:
         dynamic_model.model_fields[name].description = param_doc.description
-
-    dynamic_model.__doc__ = docstring.short_description + "\n" + docstring.long_description
+        
+    dynamic_model.__doc__ = (docstring.short_description if docstring.short_description is not None else "") + "\n" + (docstring.long_description if docstring.long_description is not None else "")
 
     def run_method_wrapper(self):
         func_args = {name: getattr(self, name) for name, _ in dynamic_fields.items()}


### PR DESCRIPTION
docstring_parser's parse will yield docstring.short_description or docstring.long_description as None, when no correspond scope exists in function documentation