### PR TITLE
Fix GEMMA_2, LLAMA_3, and PHI_3 MessagesFormatter

### DIFF
--- a/src/llama_cpp_agent/messages_formatter.py
+++ b/src/llama_cpp_agent/messages_formatter.py
@@ -160,7 +160,7 @@ llama_2_prompt_markers = {
 llama_3_prompt_markers = {
     Roles.system: PromptMarkers("""<|start_header_id|>system<|end_header_id|>\n""", """<|eot_id|>"""),
     Roles.user: PromptMarkers("""<|start_header_id|>user<|end_header_id|>\n""", """<|eot_id|>"""),
-    Roles.assistant: PromptMarkers("""<|start_header_id|>assistant<|end_header_id|>\n""", """<|eot_id|>"""),
+    Roles.assistant: PromptMarkers("""<|start_header_id|>assistant<|end_header_id|>\n\n""", """<|eot_id|>"""),
     Roles.tool: PromptMarkers("""<|start_header_id|>function_calling_results<|end_header_id|>\n""", """<|eot_id|>"""),
 }
 

--- a/src/llama_cpp_agent/messages_formatter.py
+++ b/src/llama_cpp_agent/messages_formatter.py
@@ -337,7 +337,7 @@ phi_3_chat_formatter = MessagesFormatter(
     "",
     phi_3_chat_prompt_markers,
     True,
-    ["<|end|>", "<|end_of_turn|>"],
+    ["<|end|>", "<|endoftext|>"],
     use_user_role_for_function_call_result=True,
 )
 

--- a/src/llama_cpp_agent/messages_formatter.py
+++ b/src/llama_cpp_agent/messages_formatter.py
@@ -180,7 +180,7 @@ neural_chat_prompt_markers = {
 gemma_2_prompt_markers = {
     Roles.system: PromptMarkers("""""", """\n\n"""),
     Roles.user: PromptMarkers("""<start_of_turn>user\n""", """<end_of_turn>\n"""),
-    Roles.assistant: PromptMarkers("""<start_of_turn>model\n""", """<end_of_turn>\n"""),
+    Roles.assistant: PromptMarkers("""<start_of_turn>model\n\n""", """<end_of_turn>\n"""),
     Roles.tool: PromptMarkers("", ""),
 }
 code_ds_prompt_markers = {


### PR DESCRIPTION
Gemma needs another \n in the prompt template to avoid slow processing of follow up prompts, see #54

![Screenshot from 2024-07-07 19-16-28](https://github.com/Maximilian-Winter/llama-cpp-agent/assets/68678880/8b69d107-839f-409c-a9b8-13d8d19666b9)
As can be seen in the attached screenshot the prompt processing is much faster.
Before: The new user prompt plus the models previous answer are processed (42 tokens)
After: Only the new user prompt is processed (18 tokens)

The longer the models previous answer the more relevant...

Probably there are similar issues in all other prompt templates.