### PR TITLE
Update `llama_cpp_server.py` fixing bugs with non-streaming response

### DIFF
--- a/src/llama_cpp_agent/providers/llama_cpp_server.py
+++ b/src/llama_cpp_agent/providers/llama_cpp_server.py
@@ -200,7 +200,7 @@ class LlamaCppServerProvider(LlmProvider):
         )
         data = response.json()
 
-        returned_data = {"choices": [{"text": data["content"]}]}
+        returned_data = data # This follows the same structure used by agent
         return returned_data
 
     def create_chat_completion(
@@ -309,7 +309,11 @@ class LlamaCppServerProvider(LlmProvider):
         if not self.llama_cpp_python_server:
             settings_dictionary["mirostat"] = settings_dictionary.pop("mirostat_mode")
         if self.llama_cpp_python_server:
+            # Max tokens shouldn't be -1
             settings_dictionary["max_tokens"] = settings_dictionary.pop("n_predict")
+            if settings_dictionary["max_tokens"] == -1:
+                settings_dictionary["max_tokens"] = 8192 # A good value for non-limited responses
+                # But tests can be done in case of value stoping structured output generation
 
         settings_dictionary["stop"] = settings_dictionary.pop(
             "additional_stop_sequences"


### PR DESCRIPTION
This commit fixes the following bugs:
- `max_tokens` as `-1` return a error from python server, set it a default value as 8192 tokens for maximum capacity, but tests can be done with this;
- `data["content"]` doesn't exist in llama-cpp-python server for response, better use the entire response json data because it's the same structure used by extractor.