### PR TITLE
Fix Trailing Bracket in GBNF generation

### DIFF
--- a/src/llama_cpp_agent/gbnf_grammar_generator/gbnf_grammar_from_pydantic_models.py
+++ b/src/llama_cpp_agent/gbnf_grammar_generator/gbnf_grammar_from_pydantic_models.py
@@ -641,7 +641,7 @@ def generate_gbnf_grammar(
 
     fields_joined = r' "," '.join(model_rule_parts)
     if fields_joined != "":
-        model_rule = rf'{model_name} ::= "{{" {fields_joined} ws "}}"'
+        model_rule = rf'{model_name} ::= "{{" {fields_joined} '
     else:
         model_rule = rf'{model_name} ::= "{{" "}}"'
 
@@ -650,10 +650,12 @@ def generate_gbnf_grammar(
         model_rule += '"\\n" ws "}"'
         model_rule += '"\\n" triple-quoted-string'
         has_special_string = True
-    if has_markdown_code_block:
+    elif has_markdown_code_block:
         model_rule += '"\\n" ws "}"'
         model_rule += '"\\n" markdown-code-block'
         has_special_string = True
+    else:
+        model_rule += ' ws "}"'
     all_rules = [model_rule] + nested_rules
 
     return all_rules, has_special_string
@@ -764,8 +766,8 @@ def generate_gbnf_grammar_from_pydantic_models(
                 model_rules[
                     0
                 ] += rf' "," ws "\"{request_heartbeat_field_name}\""  ":" ws boolean '
-            if not has_special_string:
-                model_rules[0] += r' ws "}"'
+            # if not has_special_string:
+            #     model_rules[0] += r' ws "}"'
 
             all_rules.extend(model_rules)
 


### PR DESCRIPTION
The GBNF generator adds an additional bracket at then end of the GBNF grammar, leading to malformed model output.

e.g.:
```python
import pydantic
from llama_cpp_agent.gbnf_grammar_generator.gbnf_grammar_from_pydantic_models import generate_gbnf_grammar_from_pydantic_models
class Constraint(pydantic.BaseModel):
    property: str
    value: str
    modifier: str
    
class Entity(pydantic.BaseModel):
    name: str
    constraints: list[Constraint]
    
class Relation(pydantic.BaseModel):
    entity:str
    relation:str
    target:str

class EntitiesRelations(pydantic.BaseModel):
    relations: list[Relation]
    entities: list[Entity]

gbnf_erl = generate_gbnf_grammar_from_pydantic_models([EntitiesRelations], "EntitiesRelations", add_inner_thoughts=False)
print(gbnf_erl)
```
Prints:
```gbnf
root ::= entities-relations
entities-relations ::= (" "| "\n") "{" ws "\"chain_of_thought\""  ":" ws string (("," ws "\"EntitiesRelations\""  ":" ws grammar-models)? | ws "}")
grammar-models ::= entities-relations-grammar-model
entities-relations-grammar-model ::= "\"EntitiesRelations\"" "," ws "\"None\"" ": " entities-relations

entities-relations ::= "{"  ws "\"relations\"" ": " entities-relations-relations ","  ws "\"entities\"" ": " entities-relations-entities ws "}" ws "}"
relation ::= "{"  ws "\"entity\"" ": " string ","  ws "\"relation\"" ": " string ","  ws "\"target\"" ": " string ws "}"
entities-relations-relations ::= "[" ws (relation)? ("," ws relation)* ws "]" 
entity ::= "{"  ws "\"name\"" ": " string ","  ws "\"constraints\"" ": " entity-constraints ws "}"
constraint ::= "{"  ws "\"property\"" ": " string ","  ws "\"value\"" ": " string ","  ws "\"modifier\"" ": " string ws "}"
entity-constraints ::= "[" ws (constraint)? ("," ws constraint)* ws "]" 
entities-relations-entities ::= "[" ws (entity)? ("," ws entity)* ws "]" 

boolean ::= "true" | "false"
null ::= "null"
string ::= "\"" (
        [^"\\] |
        "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F])
      )* "\""
ws ::= ([ \t\n]+)
number ::= "-"? ([0-9]+ | [0-9]+ "." [0-9]+) ([eE] [-+]? [0-9]+)?
```
With an additional `ws "}"`, which is fixed using this pull request. I have, however, not tested the markdown/special character options which had a bogus grammar generation anyways (if both occur, they also generate additional closing brackets!)